### PR TITLE
Mark solutions as learning/learnt

### DIFF
--- a/backend/programs/backend/src/instructions/like_solution.rs
+++ b/backend/programs/backend/src/instructions/like_solution.rs
@@ -3,7 +3,6 @@ use anchor_lang::prelude::*;
 use crate::{constants::*, state::*, error::{LikeError, CaseError}, utils::is_liked};
 
 #[derive(Accounts)]
-#[instruction(solution: String)]
 pub struct LikeSolution<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,

--- a/backend/programs/backend/src/instructions/mod.rs
+++ b/backend/programs/backend/src/instructions/mod.rs
@@ -6,6 +6,7 @@ pub mod create_case;
 pub mod init_global_config;
 pub mod revoke_privilege;
 pub mod send_user_info;
+pub mod set_learning_status;
 pub mod like_solution;
 pub mod remove_like;
 
@@ -17,5 +18,6 @@ pub use create_case::*;
 pub use init_global_config::*;
 pub use revoke_privilege::*;
 pub use send_user_info::*;
+pub use set_learning_status::*;
 pub use like_solution::*;
 pub use remove_like::*;

--- a/backend/programs/backend/src/instructions/set_learning_status.rs
+++ b/backend/programs/backend/src/instructions/set_learning_status.rs
@@ -1,0 +1,25 @@
+use anchor_lang::prelude::*;
+
+use crate::{constants::*, state::*, error::LikeError};
+
+#[derive(Accounts)]
+pub struct SetLearningStatus<'info> {
+    #[account(mut)]
+    pub signer: Signer<'info>,
+
+    /// CHECK: no seeds needed because it can be any case
+    pub case: Account<'info, Case>,
+
+    #[account(mut, seeds = [LIKE_TAG.as_ref(), signer.key().as_ref(), case.key().as_ref()], bump)]
+    pub like: Account<'info, Like>,
+}
+
+pub fn handler(ctx: Context<SetLearningStatus>, status: LearningStatus) -> Result<()> {
+    if let None = ctx.accounts.case.solutions.get(ctx.accounts.like.solution_index as usize) {
+        err!(LikeError::SolutionDoesntExist)?;
+    }
+
+    ctx.accounts.like.learning_status = status;
+
+    Ok(())
+}

--- a/backend/programs/backend/src/lib.rs
+++ b/backend/programs/backend/src/lib.rs
@@ -69,6 +69,11 @@ pub mod backend {
         remove_like::handler(ctx)
     }
 
+    /// Sets learning status. Needs to like solution first
+    pub fn set_learning_status(ctx: Context<SetLearningStatus>, status: LearningStatus) -> Result<()> {
+        set_learning_status::handler(ctx, status)
+    }
+
     //////////// User profiles ////////////
 
     /// Initializes user info PDA (user)

--- a/backend/programs/backend/src/state/like.rs
+++ b/backend/programs/backend/src/state/like.rs
@@ -2,6 +2,14 @@ use anchor_lang::prelude::*;
 
 use crate::constants::DISCRIMINATOR_LENGTH;
 
+#[repr(u8)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub enum LearningStatus {
+    NotLearnt = 0, // evil
+    Learning,
+    Learnt,
+}
+
 #[account]
 pub struct Like {
     /// User who liked
@@ -10,6 +18,8 @@ pub struct Like {
     pub case: Pubkey,
     /// Index of solution that has been liked
     pub solution_index: u8,
+    /// Learning status
+    pub learning_status: LearningStatus,
 }
 
 impl Like {
@@ -17,6 +27,7 @@ impl Like {
         DISCRIMINATOR_LENGTH +
         32 + // user
         32 + // case
-        1    // solution_index
+        1  + // solution_index
+        1    // learning_status
     ;
 }

--- a/backend/tests/constants.ts
+++ b/backend/tests/constants.ts
@@ -9,3 +9,5 @@ export const CASE_TAG = "case";
 export const GLOBAL_CONFIG_TAG = "global-config";
 
 export const CASE_BASE_LEN = 193;
+
+export const LIKE_TAG = "like";

--- a/backend/tests/utils.ts
+++ b/backend/tests/utils.ts
@@ -1,5 +1,5 @@
 import * as anchor from "@coral-xyz/anchor";
-import { CASE_TAG, PRIVILEGE_TAG } from "./constants";
+import { CASE_TAG, LIKE_TAG, PRIVILEGE_TAG } from "./constants";
 
 export const fundAccounts = async (
   provider: anchor.AnchorProvider,
@@ -41,6 +41,17 @@ export const casePda = (
 ) => {
   return anchor.web3.PublicKey.findProgramAddressSync(
     [Buffer.from(CASE_TAG), Buffer.from(set), Buffer.from(id)],
+    pid
+  )[0];
+};
+
+export const likePda = (
+  user: anchor.web3.PublicKey,
+  casE: anchor.web3.PublicKey,
+  pid: anchor.web3.PublicKey
+) => {
+  return anchor.web3.PublicKey.findProgramAddressSync(
+    [Buffer.from(LIKE_TAG), user.toBuffer(), casE.toBuffer()],
     pid
   )[0];
 };


### PR DESCRIPTION
Rebase this to main after #20 is merged.

fixes #18 

## Feature description
Any user can mark a solution as "NotLearnt", "Learning", "Learnt". Condition is they need to have liked it before. Why? Because I coded this