### PR TITLE
feat: WCA-complete 3x3 validator!

### DIFF
--- a/backend/programs/backend/src/constants.rs
+++ b/backend/programs/backend/src/constants.rs
@@ -19,7 +19,7 @@ pub const MAX_LOCATION_LENGTH: usize = 100;
 
 pub const MAX_SET_NAME_LENGTH: usize = 20;
 
-pub const MAX_SETUP_LENGTH: usize = 100;
+pub const MAX_SETUP_LENGTH: usize = 150;
 
 pub const MAX_SOLUTIONS_ALLOWED: u8 = 200;
 

--- a/backend/programs/backend/src/error.rs
+++ b/backend/programs/backend/src/error.rs
@@ -68,6 +68,15 @@ pub enum CaseError {
     #[msg("Case has over MAX_SOLUTIONS_ALLOWED solutions.")]
     MaxSolutionsAllowed,
 
+    #[msg("Set name too long")]
+    MaxSetNameLength,
+
+    #[msg("Case id too long")]
+    MaxCaseIdLength,
+
+    #[msg("Setup length too long")]
+    MaxSetupLength,
+
     #[msg("Catastrophic failure - world has ended")]
     Cataclysm,
 }

--- a/backend/programs/backend/src/instructions/create_case.rs
+++ b/backend/programs/backend/src/instructions/create_case.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::{state::*, constants::*, utils::*, error::{CubeError, TreasuryError}};
+use crate::{state::*, constants::*, utils::*, error::{CubeError, CaseError, TreasuryError}};
 
 #[derive(Accounts)]
 #[instruction(set: String, id: String)]
@@ -37,6 +37,10 @@ pub fn handler(
     id: String,
     setup: String,
 ) -> Result<()> {
+    require!(set.len() < MAX_SET_NAME_LENGTH, CaseError::MaxSetNameLength);
+    require!(id.len() < MAX_CASE_ID_LENGTH, CaseError::MaxCaseIdLength);
+    require!(setup.len() < MAX_SETUP_LENGTH, CaseError::MaxSetupLength);
+
     // Refund lamports
     let case_rent = ctx.accounts.rent.minimum_balance(Case::BASE_LEN + Case::extra_size_for_set(&set));
     require!(

--- a/backend/programs/backend/src/move_def/cube_move_def.rs
+++ b/backend/programs/backend/src/move_def/cube_move_def.rs
@@ -7,105 +7,149 @@
 /// Later we store the definition for each move in its own index and the inverse in the next one
 /// B'=1, D'=3, etc.
 /// 
+/// Slice moves are shifted by -63 to find room for them and their inverse
+/// E=69, M=77, S=83
+/// E=6,  M=14, S=21
+/// 
 
 // Permutation vectors + Orientation masks
 
 /// UBL UBR UFR UFL DFL DFR DBR DBL
 pub static CP: &[[usize; 4]] = &[
     [7,6,1,0], // B
-    [0,1,6,7], // inv
+    [0,1,6,7], // B'
     [4,5,6,7], // D
-    [7,6,5,4], // inv
+    [7,6,5,4], // D'
     [2,5,4,3], // F
-    [3,4,5,2], // inv
+    [3,4,5,2], // F'
     [0,0,0,0], // fill
     [0,0,0,0], // fill
     [0,0,0,0], // fill
     [0,0,0,0], // fill
     [3,4,7,0], // L
-    [0,7,4,3], // inv
+    [0,7,4,3], // L'
     [0,0,0,0], // fill
     [0,0,0,0], // fill
     [0,0,0,0], // fill
     [0,0,0,0], // fill
     [6,5,2,1], // R
-    [1,2,5,6], // inv
+    [1,2,5,6], // R'
+    [0,0,0,0], // fill
+    [0,0,0,0], // fill
+    [0,0,0,0], // fill
     [0,0,0,0], // fill
     [0,1,2,3], // U
-    [3,2,1,0], // inv
+    [3,2,1,0], // U'
 ];
 
 /// UB UR UF UL BL BR FR FL DF DR DB DL
 pub static EP: &[[usize; 4]] = &[
     [4,10,5,0],  // B
-    [0,5,10,4],  // inv
+    [0,5,10,4],  // B'
     [8,9,10,11], // D
-    [11,10,9,8], // inv
+    [11,10,9,8], // D'
     [2,6,8,7],   // F
-    [7,8,6,2],   // inv
-    [0,0,0,0],   // fill
-    [0,0,0,0],   // fill
+    [7,8,6,2],   // F'
+    [7,6,5,4],   // E
+    [4,5,6,7],   // E'
     [0,0,0,0],   // fill
     [0,0,0,0],   // fill
     [3,7,11,4],  // L
-    [4,11,7,3],  // inv
+    [4,11,7,3],  // L'
     [0,0,0,0],   // fill
     [0,0,0,0],   // fill
-    [0,0,0,0],   // fill
-    [0,0,0,0],   // fill
+    [0,2,8,10],  // M
+    [10,8,2,0],  // M'
     [1,5,9,6],   // R
-    [6,9,5,1],   // inv
+    [6,9,5,1],   // R'
     [0,0,0,0],   // fill
+    [0,0,0,0],   // fill
+    [1,9,11,3],  // S
+    [3,11,9,1],  // S'
     [0,1,2,3],   // U
-    [3,2,1,0],   // inv
+    [3,2,1,0],   // U'
 ];
 
 /// 0 = none, 1 = cw, 2 = ccw
 pub static CO: &[Option<[u8; 8]>] = &[
     Some([1,2,0,0,0,0,1,2]),    // B
-    Some([1,2,0,0,0,0,1,2]),    // inv
+    Some([1,2,0,0,0,0,1,2]),    // B'
     None,                       // D
-    None,                       // inv
+    None,                       // D'
     Some([0,0,1,2,1,2,0,0]),    // F
-    Some([0,0,1,2,1,2,0,0]),    // inv
+    Some([0,0,1,2,1,2,0,0]),    // F'
     None,                       // fill
     None,                       // fill
     None,                       // fill
     None,                       // fill
     Some([2,0,0,1,2,0,0,1]),    // L
-    Some([2,0,0,1,2,0,0,1]),    // inv
+    Some([2,0,0,1,2,0,0,1]),    // L'
     None,                       // fill
     None,                       // fill
     None,                       // fill
     None,                       // fill
     Some([0,1,2,0,0,1,2,0]),    // R
-    Some([0,1,2,0,0,1,2,0]),    // inv
+    Some([0,1,2,0,0,1,2,0]),    // R'
+    None,                       // fill
+    None,                       // fill
+    None,                       // fill
     None,                       // fill
     None,                       // U
-    None,                       // inv
+    None,                       // U'
 ];
 
 /// 1 = unoriented
 pub static EO: &[Option<[u8; 12]>] = &[
     Some([1,0,0,0,1,1,0,0,0,0,1,0]),    // B
-    Some([1,0,0,0,1,1,0,0,0,0,1,0]),    // inv
+    Some([1,0,0,0,1,1,0,0,0,0,1,0]),    // B'
     None,                               // D
-    None,                               // inv
+    None,                               // D'
     Some([0,0,1,0,0,0,1,1,1,0,0,0]),    // F
-    Some([0,0,1,0,0,0,1,1,1,0,0,0]),    // inv
-    None,                               // fill
-    None,                               // fill
+    Some([0,0,1,0,0,0,1,1,1,0,0,0]),    // F'
+    Some([0,0,0,0,1,1,1,1,0,0,0,0]),    // E
+    Some([0,0,0,0,1,1,1,1,0,0,0,0]),    // E'
     None,                               // fill
     None,                               // fill
     None,                               // L
-    None,                               // inv
+    None,                               // L'
     None,                               // fill
     None,                               // fill
-    None,                               // fill
-    None,                               // fill
+    Some([1,0,1,0,0,0,0,0,1,0,1,0]),    // M
+    Some([1,0,1,0,0,0,0,0,1,0,1,0]),    // M'
     None,                               // R
-    None,                               // inv
+    None,                               // R'
     None,                               // fill
+    None,                               // fill
+    Some([0,1,0,1,0,0,0,0,0,1,0,1]),    // S
+    Some([0,1,0,1,0,0,0,0,0,1,0,1]),    // S'
     None,                               // U
-    None,                               // inv
+    None,                               // U'
+];
+
+/// U B R F L D
+pub static XP: &[Option<[usize; 4]>] = &[
+    None,            // fill
+    None,            // fill
+    None,            // fill
+    None,            // fill
+    None,            // fill
+    None,            // fill
+    Some([4,3,2,1]), // E
+    Some([1,2,3,4]), // E'
+    None,            // fill
+    None,            // fill
+    None,            // fill
+    None,            // fill
+    None,            // fill
+    None,            // fill
+    Some([0,3,5,1]), // M
+    Some([1,5,3,0]), // M'
+    None,            // fill
+    None,            // fill
+    None,            // fill
+    None,            // fill
+    Some([0,2,5,4]), // S
+    Some([4,5,2,0]), // S'
+    None,            // fill
+    None,            // fill
 ];

--- a/backend/programs/backend/src/utils/moves.rs
+++ b/backend/programs/backend/src/utils/moves.rs
@@ -2,7 +2,7 @@
 
 #![allow(non_snake_case)]
 
-use crate::move_def::{pyra_move_def::{EP as P_EP, EO as P_EO, XO}, cube_move_def::*};
+use crate::{move_def::{pyra_move_def::{EP as P_EP, EO as P_EO, XO}, cube_move_def::*}, error::CubeError};
 use super::{Cube, Pyra};
 
 /// Rotate four elements
@@ -40,7 +40,8 @@ pub fn apply_to_cube(
     cp_indices: [usize; 4],
     ep_indices: [usize; 4],
     co_mask_opt: Option<[u8; 8]>,
-    eo_mask_opt: Option<[u8; 12]>
+    eo_mask_opt: Option<[u8; 12]>,
+    xp_indices_opt: Option<[usize; 4]>,
 ) -> Cube {
     // Cycle all four arrays
     apply_permutation(&mut cube.co, cp_indices);
@@ -55,6 +56,11 @@ pub fn apply_to_cube(
 
     if let Some(eo_mask) = eo_mask_opt {
         cube.eo = apply_orientation(&cube.eo, &eo_mask, 2).try_into().unwrap();
+    }
+
+    // Update centers if needed
+    if let Some(xp_indices) = xp_indices_opt {
+        apply_permutation(&mut cube.xp, xp_indices);
     }
 
     cube
@@ -87,18 +93,19 @@ pub fn apply_to_pyra(
 pub fn move_cube(mov: usize, cube: &mut Cube) {
     *cube = apply_to_cube(
         cube.clone(),
-        CP[mov],
-        EP[mov],
-        CO[mov],
-        EO[mov],
+        *CP.get(mov).ok_or(CubeError::InvalidMove).unwrap(),
+        *EP.get(mov).ok_or(CubeError::InvalidMove).unwrap(),
+        *CO.get(mov).ok_or(CubeError::InvalidMove).unwrap(),
+        *EO.get(mov).ok_or(CubeError::InvalidMove).unwrap(),
+        *XP.get(mov).ok_or(CubeError::InvalidMove).unwrap(),
     );
 }
 
 pub fn move_pyra(mov: usize, pyra: &mut Pyra) {
     *pyra = apply_to_pyra(
         pyra.clone(),
-        P_EP[mov],
-        XO[mov],
-        P_EO[mov],
+        *P_EP.get(mov).ok_or(CubeError::InvalidMove).unwrap(),
+        *XO.get(mov).ok_or(CubeError::InvalidMove).unwrap(),
+        *P_EO.get(mov).ok_or(CubeError::InvalidMove).unwrap(),
     );
 }

--- a/backend/programs/backend/src/utils/puzzles/cube.rs
+++ b/backend/programs/backend/src/utils/puzzles/cube.rs
@@ -2,7 +2,7 @@ use anchor_lang::prelude::*;
 
 use std::{borrow::BorrowMut, str::SplitWhitespace};
 
-use crate::error::CubeError;
+use crate::{error::CubeError, utils::{wide_to_slice, opp_slice}};
 
 use super::super::move_cube;
 
@@ -17,6 +17,8 @@ pub struct Cube {
     pub eo: [u8; 12],
     /// Edge permutation vector
     pub ep: [u8; 12],
+    /// Center position vector
+    pub xp: [u8; 6],
 }
 
 impl Cube {
@@ -29,6 +31,7 @@ impl Cube {
             cp: [1,2,3,4,5,6,7,8],
             eo: [0; 12],
             ep: [1,2,3,4,5,6,7,8,9,10,11,12],
+            xp: [1,2,3,4,5,6],
         }
     }
 
@@ -46,31 +49,62 @@ impl Cube {
         // Iterate through every move and apply it if valid
         let moves: SplitWhitespace = moves.split_whitespace();
         for mov in moves {
-            if ![
-                "R","U","F","L","D","B",
-                "R'","U'","F'","L'","D'","B'",
-                "R2","U2","F2","L2","D2","B2",
-            ].contains(&mov) {
-                return Err(error!(CubeError::InvalidMove));
+            // Check for rotations (UTTERLY questionable mental health)
+            match mov {
+                "x" => { self.apply_moves("L' Rw")?; continue; },
+                "y" => { self.apply_moves("U Dw'")?; continue; },
+                "z" => { self.apply_moves("F Bw'")?; continue; },
+                "x\'" => { self.apply_moves("L Rw'")?; continue; },
+                "y\'" => { self.apply_moves("U' Dw")?; continue; },
+                "z\'" => { self.apply_moves("F' Bw")?; continue; },
+                "x2" => { self.apply_moves("L2 Rw2")?; continue; },
+                "y2" => { self.apply_moves("U2 Dw2")?; continue; },
+                "z2" => { self.apply_moves("F2 Bw2")?; continue; },
+                _ => (),
             }
 
             // Letter into index (shifted ASCII value)
-            // B=66, D=68, F=70, L=76, R=82, U=85
-            // B=0,  D=2,  F=4,  L=10, R=16, U=19
-            let base_move: usize = mov.chars().nth(0).unwrap() as usize - 66;
+            // B=66, D=68, E=69, F=70, L=76, M=77, R=82, S=83, U=85
+            // B=0,  D=2, *E=6,  F=4,  L=10,*M=14, R=16,*S=20, U=22
+
+            let mut base_move: usize = (mov.chars().nth(0).unwrap() as usize)
+                .checked_sub(66)
+                .ok_or(CubeError::InvalidMove)?;
+
+            // E, M, S need to be shifted 3 more places. U gets shifted too for being odd and annoying.
+            // Since they are the only numbers here that are 1 mod 2 we can save a comparison
+            // Guido D. did this like this to avoid writing a single "if" statement and preserve O(1) indexing
+            // He does not regret writing the following line
+            base_move += 3 * (base_move % 2);
+            
             // Direction
-            if let Some(dir) = mov.chars().nth(1) {
-                match dir {
-                    '\'' => move_cube(base_move + 1, self.borrow_mut()),
-                    '2' => {
-                        move_cube(base_move, self.borrow_mut());
-                        move_cube(base_move, self.borrow_mut());
-                    },
-                    _ => (),
-                }
-            }
-            else {
-                move_cube(base_move, self.borrow_mut());
+            match mov.chars().nth(1) {
+                Some('\'') => move_cube(base_move + 1, self.borrow_mut()),
+                Some('2')=> {
+                    move_cube(base_move, self.borrow_mut());
+                    move_cube(base_move, self.borrow_mut());
+                },
+                Some('w')=> {
+                    match mov.chars().nth(2) {
+                        Some('\'') => {
+                            move_cube(base_move + 1, self.borrow_mut());
+                            move_cube(opp_slice(wide_to_slice(base_move)?)?, self.borrow_mut());
+                        },
+                        Some('2') => {
+                            move_cube(base_move, self.borrow_mut());
+                            move_cube(wide_to_slice(base_move)?, self.borrow_mut());
+                            move_cube(base_move, self.borrow_mut());
+                            move_cube(wide_to_slice(base_move)?, self.borrow_mut());
+                        }
+                        None => {
+                            move_cube(base_move, self.borrow_mut());
+                            move_cube(wide_to_slice(base_move)?, self.borrow_mut());
+                        },
+                        _ => err!(CubeError::InvalidMove)?,
+                    }
+                },
+                None => move_cube(base_move, self.borrow_mut()),
+                _ => err!(CubeError::InvalidMove)?,
             }
         }
 
@@ -83,7 +117,8 @@ impl Cube {
             self.co == [0,0,0,0,0,0,0,0] &&
             self.cp == [1,2,3,4,5,6,7,8] &&
             self.eo == [0,0,0,0,0,0,0,0,0,0,0,0] &&
-            self.ep == [1,2,3,4,5,6,7,8,9,10,11,12]
+            self.ep == [1,2,3,4,5,6,7,8,9,10,11,12] &&
+            self.xp == [1,2,3,4,5,6]
         ) {
             return Err(error!(CubeError::UnsolvedCube));
         }
@@ -97,7 +132,8 @@ impl Cube {
             self.co        == [0,0,0,0,0,0,0,0] &&
             self.cp[4..8]  == [5,6,7,8] &&
             self.eo        == [0,0,0,0,0,0,0,0,0,0,0,0] &&
-            self.ep[4..12] == [5,6,7,8,9,10,11,12]
+            self.ep[4..12] == [5,6,7,8,9,10,11,12] &&
+            self.xp        == [1,2,3,4,5,6]
         ) {
             return Err(error!(CubeError::UnsolvedCube));
         }
@@ -111,7 +147,8 @@ impl Cube {
             self.co[4..8]  == [0,0,0,0] &&
             self.cp[4..8]  == [5,6,7,8] &&
             self.eo[4..12] == [0,0,0,0,0,0,0,0] &&
-            self.ep[4..12] == [5,6,7,8,9,10,11,12]
+            self.ep[4..12] == [5,6,7,8,9,10,11,12] &&
+            self.xp        == [1,2,3,4,5,6]
         ) {
             return Err(error!(CubeError::UnsolvedCube));
         }
@@ -129,7 +166,9 @@ impl Cube {
             self.eo[11]    == 0 &&
             self.ep[4..8]  == [5,6,7,8] &&
             self.ep[9]     == 10 &&
-            self.ep[11]    == 12
+            self.ep[11]    == 12 &&
+            self.xp[2]     == 3 &&
+            self.xp[4]     == 5
         ) {
             return Err(error!(CubeError::UnsolvedCube));
         }

--- a/backend/programs/backend/src/utils/puzzles/utils.rs
+++ b/backend/programs/backend/src/utils/puzzles/utils.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::utils::{Cube, Pyra};
+use crate::{utils::{Cube, Pyra}, error::CubeError};
 
 pub fn validate_set_setup_solution(set: &str, setup: &str, solution: &str) -> Result<()> {
     match set {
@@ -17,4 +17,31 @@ pub fn validate_set_setup_solution(set: &str, setup: &str, solution: &str) -> Re
     }
 
     Ok(())
+}
+
+/// Converts i.e Bw to S' (it is applied as B S') in [crate::cube.rs])
+/// B =0,  D=2, F=4,  L=10,  R =16, U=22
+/// S'=21, E=6, S=20, M=14,  M'=15, E'=7
+pub fn wide_to_slice(base_move: usize) -> Result<usize> {
+    match base_move {
+        0 => Ok(21),
+        2 => Ok(6),
+        4 => Ok(20),
+        10 => Ok(14),
+        16 => Ok(15),
+        22 => Ok(7),
+        _ => err!(CubeError::InvalidMove)?,
+    }
+}
+
+pub fn opp_slice(base_move: usize) -> Result<usize> {
+    match base_move {
+        6 => Ok(7),
+        7 => Ok(6),
+        14 => Ok(15),
+        15 => Ok(14),
+        20 => Ok(21),
+        21 => Ok(20),
+        _ => err!(CubeError::InvalidMove)?,
+    }
 }

--- a/backend/tests/constants.ts
+++ b/backend/tests/constants.ts
@@ -8,7 +8,7 @@ export const CASE_TAG = "case";
 
 export const GLOBAL_CONFIG_TAG = "global-config";
 
-export const CASE_BASE_LEN = 151;
+export const CASE_BASE_LEN = 201;
 
 export const LIKE_CERTIFICATE_TAG = "like-certificate";
 


### PR DESCRIPTION
# Descripción
Resuelve #39. Ahora se pueden usar los movimientos de capa doble (Rw, Lw', Fw2, etc.), de capas internas (M, E', S2, etc.) y rotaciones (x, y', z2, etc.).

Con esto Cubitorium acepta los [54 movimientos válidos](https://www.worldcubeassociation.org/regulations/#12a) según el reglamento de la WCA*!

>`*Nota: Técnicamente cosas como "2Rw2" son válidas también en 3x3 pero eso es lo mismo que "Rw2" y nadie, NADIE JAMÁS usa esa otra forma. Es medio un hueco legal en el reglamento que quedó y solo yo lo sé me parece`

# But how
no se sabe

# Implementación
En el archivo `cube_move_def.rs` se ven algunos arrays insólitos con números inconcebiblemente falopa. Esas son las descripciones de cómo se afecta el cubo según cada movimiento. Como soy un enfermo mental hice una cosa mística para poder hacer la búsqueda dentro de ese array de la forma más eficiente posible, es decir en tiempo constante (O(1)) de ser posible, y con poco cómputo (o sea no pintaba usar un HashMap o algo así).

Por eso, como el conjunto de entrada son letras mayúsculas, decidí hacer una operación aritmética simple para transformar esa letra a un entero ya que están todos bastante cerca y por ejemplo podía pasar de `B` a `0` en tan solo una resta y hacer directamente acceso directo poniendo lo que yo quería relacionar a `B` en el índice 0.

Esto era chévere con los movimientos `R F L D U B` porque estaba todo cerca y además me permitía poner los movimientos opuestos en el elemento posterior (o sea si `B` es 0 entonces `B'` es el 1).
Pero acá tuve que agregar las letras `M, E, S` y medio se me descajetó todo un poco.

Para poder seguir usando este concepto y no sacrificar el acceso constante que tanto me gustaba tuve que aplicarle un shift adicional a estas tres letras para que no me cayera el inverso de alguna en la misma posición que otra cosa (por ejemplo `F` es 70 y `E` es 69 así que `E'` sería también 70 y no me servía...).
De ahí surgen cosas horribles como esto:

```rust
// E, M, S need to be shifted 3 more places. U gets shifted too for being odd and annoying.
// Since they are the only numbers here that are 1 mod 2 we can save a comparison
// Guido D. did this like this to avoid writing a single "if" statement and preserve O(1) indexing
// He does not regret writing the following line
base_move += 3 * (base_move % 2);
```

## Otros detalles más normales fuera de la esquizofrenia

Más allá de eso, lo que necesité hacer fue agregar la representación de los centros (ya que de golpe son importantes, así que vino al mundo el `pub xp: [u8; 6],`, acomodar un poco los métodos de `Cube` en `cube.rs` para poder parsear bien cosas como  `Rw`, `x`, `M2` y demases, y luego revoleé un par de líneas de código por donde me pareció piola.

# Más cosas que me gustaría comentar

- Cambié `MAX_SETUP_LENGTH` a 150 porque igual esto va a cambiar cuando haga #44 que me re copa
- Agregué validaciones que faltaban en `create_case()`
- Arreglé un poquito algunos comments que nadie va a leer en `cube_move_def.rs`
- Hice apenas más eficiente la validación de que los movimientos sean válidos. Creo. Y si no, al menos lo intenté.
- Dejé un nuevo [horror de Rust](https://github.com/crisszkutnik/final-thesis/pull/49/files#diff-43bf7a0b14bfca0240caba120f8c5dfdfd84da3176f7c42f36a68be7d8c16d6dR52).
- Agregué un test que chequea la WCA-completeness de este monstruo aberrante y funciona bien.